### PR TITLE
Add support for string min/max length to json_freetext

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2023 Noam Gat
+              2023 Jarno Elonen
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/lmformatenforcer/characterlevelparser.py
+++ b/lmformatenforcer/characterlevelparser.py
@@ -31,12 +31,12 @@ class CharacterLevelParser(abc.ABC):
         """Return True if the parser is in a state where it can end (potentially finished parsing the desired structure), and False otherwise."""
         raise NotImplementedError()
     
-    def shortcut_key(self) -> Optional[str]:
-        """Optional. Return a string that denotes that this state is a repeating state, full tree traversal should be avoided."""
+    def shortcut_key(self) -> Optional[Hashable]:
+        """Optional. Return a key that denotes that this state is a repeating state, full tree traversal should be avoided."""
         return None
     
     def cache_key(self) -> Optional[Hashable]:
-        """Optional. Return a string that denotes that this state is a repeating state, and if it is visited again, results can be cached."""
+        """Optional. Return a key that denotes that this state is a repeating state, and if it is visited again, results can be cached."""
         return None
     
     @property

--- a/lmformatenforcer/tokenenforcer.py
+++ b/lmformatenforcer/tokenenforcer.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass, field
+import sys
 from typing import Callable, Dict, Hashable, List, Optional, Tuple
 import logging
 
@@ -115,7 +116,7 @@ class TokenEnforcer:
                               "CharacterLevelParser parameters")
             state.allowed_tokens = [self.eos_token_id]
 
-    def _collect_allowed_tokens(self, parser: CharacterLevelParser, tree_node: TokenizerPrefixTreeNode, allowed_tokens: List[int], shortcut_key: Optional[str]):
+    def _collect_allowed_tokens(self, parser: CharacterLevelParser, tree_node: TokenizerPrefixTreeNode, allowed_tokens: List[int], shortcut_key: Optional[Hashable]):
         allowed_tokens.extend(tree_node.tokens)
         allowed_characters = parser.get_allowed_characters()
         relevant_characters = tree_node.children.keys()
@@ -125,12 +126,19 @@ class TokenEnforcer:
         # Performance optimization: If we are in JSON freetext, all of the tokens that don't contain quote, or end with quote, are legal, so we take
         # their cached list. If the quote character is allowed, we only need to dynamically explore the cases where the string starts with a quote.
         # This breaks the elegance of the API, but otherwise it is a huge performance hit.
-        if shortcut_key == 'json_freetext':
-            allowed_tokens.extend(self.tokenizer_tree.json_freetext_tokens)
+        if type(shortcut_key) is tuple and shortcut_key[0] == 'json_freetext':
+            assert len(shortcut_key) == 4
+            _, cur_len, min_len, max_len = shortcut_key
+            cache = self.tokenizer_tree.json_freetext_tokens
+
+            min_remaining = min(cache.max_token_len, max(0, min_len - cur_len))  # no " allowed before this many chars
+            max_allowed_len = min(cache.max_token_len, max_len - cur_len)  # max new characters allowed (before ")
+
+            allowed_tokens.extend(cache.lookup_allowed_tokens(min_remaining, max_allowed_len))
             characters_to_explore = characters_to_explore.intersection(['"'])
 
         for character in characters_to_explore:
-            next_parser = parser.add_character(character )
+            next_parser = parser.add_character(character)
             next_tree_node = tree_node.children[character]
             self._collect_allowed_tokens(next_parser, next_tree_node, allowed_tokens, None)
             
@@ -155,4 +163,3 @@ class TokenEnforcer:
         return new_state
         
 
-    

--- a/lmformatenforcer/tokenenforcer.py
+++ b/lmformatenforcer/tokenenforcer.py
@@ -126,7 +126,7 @@ class TokenEnforcer:
         # Performance optimization: If we are in JSON freetext, all of the tokens that don't contain quote, or end with quote, are legal, so we take
         # their cached list. If the quote character is allowed, we only need to dynamically explore the cases where the string starts with a quote.
         # This breaks the elegance of the API, but otherwise it is a huge performance hit.
-        if type(shortcut_key) is tuple and shortcut_key[0] == 'json_freetext':
+        if isinstance(shortcut_key, tuple) and shortcut_key[0] == 'json_freetext':
             assert len(shortcut_key) == 4
             _, cur_len, min_len, max_len = shortcut_key
             cache = self.tokenizer_tree.json_freetext_tokens

--- a/lmformatenforcer/tokenizerprefixtree.py
+++ b/lmformatenforcer/tokenizerprefixtree.py
@@ -1,36 +1,104 @@
+from collections import OrderedDict
 from typing import Dict, List, Set, Tuple
 import json
 
 class TokenizerPrefixTreeNode:
-    def __init__(self):
+    def __init__(self) -> None:
         self.tokens: List[int] = []
         self.children: Dict[str, TokenizerPrefixTreeNode] = {}
+
+
+class JsonFreetextTokenCache:
+    def __init__(self, ) -> None:
+        self.token_str_to_num: Dict[str, int] = {}
+        self.allowlist_cache: Dict[Tuple[int, int], Tuple[int, ...]] = {}
+        self.max_token_len = 0
+
+
+    def add_token(self, token_str: str, token_int: int):
+        assert not self.allowlist_cache, "Cannot add more tokens after allowlists were precalculated"
+        self.token_str_to_num[token_str] = token_int
+        self.max_token_len = max(self.max_token_len, len(token_str))
+
+
+    def lookup_allowed_tokens(self, min_remaining: int, max_len: int) -> Tuple[int, ...]:
+        """
+        Get the list of tokens that are allowed within a JSON string, such that:
+        1. all candidate tokens are at most `max_len` characters long (excluding the trailing quote), and
+        2. if a token ends with a quote, it's at least `min_remaining` chars long (excluding the quote).
+        """
+        return self.allowlist_cache[(min_remaining, max_len)]
+
+
+    def freeze(self) -> None:
+        """
+        Precalculate token allowlists for all valid combinations of `min_remaining` and `max_len`
+        based on the tokens that were added with `add_token()`.
+        """
+        all_tokens: List[str] = sorted(self.token_str_to_num.keys())
+        assert all_tokens, "Cannot precalculate allowlists for an empty token list"
+        assert not any(t == '' for t in all_tokens), "Tokenizer must not contain empty tokens"
+
+        def _valid_for_min_remaining(token, min_remaining):
+            return not token.endswith('"') or len(token.rstrip('"')) >= min_remaining
+
+        def _valid_for_max_len(token, max_len):
+            return len(token.rstrip('"')) <= max_len
+
+        # Make a 2D array of constrained allowlists, indexed by tuple `(min_remaining, max_len)`
+        token_lists = {}
+        max_token_len = max(len(token) for token in all_tokens)
+        for min_remaining in range(max_token_len + 1):
+            for max_len in range(max_token_len + 1):
+                if max_len >= min_remaining:  # Skip combinations that are never used
+                    token_lists[(min_remaining, max_len)] = tuple(sorted([
+                        token for token in all_tokens
+                        if _valid_for_min_remaining(token, min_remaining) and _valid_for_max_len(token, max_len)
+                    ]))
+
+        # Deduplicate the lists to save RAM as many of them will be identical
+        unique_lists = set(token_lists.values())
+        for key, lst in token_lists.items():
+            for uniq in unique_lists:
+                if len(uniq) == len(lst) and uniq == lst:
+                    token_lists[key] = uniq
+                    break
+
+        # Turn token strings into token numbers
+        self.allowlist_cache = {
+            key: tuple(self.token_str_to_num[t] for t in lst)
+            for key, lst in token_lists.items()
+        }
+        del self.token_str_to_num
 
 
 class TokenizerPrefixTree:
     def __init__(self, regular_tokens: List[Tuple[int, str, bool]]):
         self.root = TokenizerPrefixTreeNode()
-        self.json_freetext_tokens: List[int] = []
+        self.json_freetext_tokens = JsonFreetextTokenCache()
         self.new_word_tokens: Set[int] = set()
         self.tokens_to_strs = {token_idx: token_str for token_idx, token_str, _ in regular_tokens}
         for token_idx, decoded, is_new_word in regular_tokens:
             self._add_token_to_tree(decoded, token_idx, self.root)
+
             # Performance optimization - cache the tokens of all the strings that don't contain a quote in the middle, or a line break.
             # When we are in a JSON freetext string field, they will all be permitted and this will save a lot of tree iterations.
+            has_non_trailing_backslash = '\\' in decoded[:-1]
             has_quote_before_end = '"' in decoded[0:-1]
             has_newline = "\n" in decoded or "\r" in decoded
+            if has_non_trailing_backslash or has_quote_before_end or has_newline:  # Could be illegal inside a JSON string, test it
+                try:
+                    json.loads(f'"{decoded}"')
+                except json.decoder.JSONDecodeError:
+                    continue
 
-            if not (has_quote_before_end or has_newline):
-                if '\\' in decoded[:-1]:
-                    # If there is a backslash that is not trailing, we might be in an illegal json territory. Need to verify
-                    # that is is a legal json character streak
-                    try:
-                        json.loads(f'"{decoded}"')
-                    except json.decoder.JSONDecodeError:
-                        continue
-                self.json_freetext_tokens.append(token_idx)
+            self.json_freetext_tokens.add_token(decoded, token_idx)
+
             if is_new_word:
                 self.new_word_tokens.add(token_idx)
+
+        self.json_freetext_tokens.freeze()
+
 
     def _add_token_to_tree(self, token_str: str, token_idx: int, node: TokenizerPrefixTreeNode):
         for character in token_str:

--- a/tests/test_jsonschemaparser.py
+++ b/tests/test_jsonschemaparser.py
@@ -53,93 +53,93 @@ class SampleModel(BaseModel):
 
 def test_minimal():
     test_string = '{"num":1}'
-    _test_json_schema_parsing_with_string(test_string, SampleModel.schema(), True)
+    _test_json_schema_parsing_with_string(test_string, SampleModel.model_json_schema(), True)
 
 def test_parsing_test_model():
     test_string = '{"num":1,"dec":1.1,"message":"ok","list_of_strings":["a","b","c"],"inner_dict":{"a":{"list_of_ints":[1,2,3]}}}'
-    _test_json_schema_parsing_with_string(test_string, SampleModel.schema(), True)
+    _test_json_schema_parsing_with_string(test_string, SampleModel.model_json_schema(), True)
 
 
 def test_invalid_key_in_json_string():
     test_string = '{"numa":1,"dec":1.1,"message":"ok","list_of_strings":["a","b","c"],"inner_dict":{"a":{"list_of_ints":[1,2,3]}}}'
-    _test_json_schema_parsing_with_string(test_string, SampleModel.schema(), False)
+    _test_json_schema_parsing_with_string(test_string, SampleModel.model_json_schema(), False)
 
 
 def test_incomplete_json():
     # Intentionally missing closing }
     test_string = '{"num":1,"dec":1.1,"message":"ok","list_of_strings":["a","b","c"],"inner_dict":{"a":{"list_of_ints":[1,2,3]}}'
-    _test_json_schema_parsing_with_string(test_string, SampleModel.schema(), False)
+    _test_json_schema_parsing_with_string(test_string, SampleModel.model_json_schema(), False)
 
 
 def test_invalid_value_type_in_json_string():
     test_string = '{"num:"1","dec":1.1,"message":"ok","list_of_strings":["a","b","c"],"inner_dict":{"a":{"list_of_ints":[1,2,3]}}}'
-    _test_json_schema_parsing_with_string(test_string, SampleModel.schema(), False)
+    _test_json_schema_parsing_with_string(test_string, SampleModel.model_json_schema(), False)
 
 
 def test_list_of_objects():
     test_string = '{"list_of_models":[{"list_of_ints":[1,2,3]},{"list_of_ints":[4,5,6]}],"num":1}'
-    _test_json_schema_parsing_with_string(test_string, SampleModel.schema(), True)
+    _test_json_schema_parsing_with_string(test_string, SampleModel.model_json_schema(), True)
     test_string = '{"list_of_models": [{"list_of_ints":[1, 2, 3]} , {"list_of_ints":[4,5,6]}],"num":1}'
-    _test_json_schema_parsing_with_string(test_string, SampleModel.schema(), True)
+    _test_json_schema_parsing_with_string(test_string, SampleModel.model_json_schema(), True)
 
 
 def test_simple_dict():
     test_string = '{"simple_dict":{"a":1,"b":2,"c":3},"num":1}'
-    _test_json_schema_parsing_with_string(test_string, SampleModel.schema(), True)
+    _test_json_schema_parsing_with_string(test_string, SampleModel.model_json_schema(), True)
 
 
 def test_int_enum():
     test_string = '{"enum":4,"num":1}'
-    _test_json_schema_parsing_with_string(test_string, SampleModel.schema(), True)
+    _test_json_schema_parsing_with_string(test_string, SampleModel.model_json_schema(), True)
 
 
 def test_invalid_int_enum_value():
     test_string = '{"enum":5,"num":1}'
-    _test_json_schema_parsing_with_string(test_string, SampleModel.schema(), False)
+    _test_json_schema_parsing_with_string(test_string, SampleModel.model_json_schema(), False)
 
 
 def test_str_enum():
     test_string = '{"enum_dict":{"a":"One","b":"Two","c":"Three","d":"Four"},"num":1}'
-    _test_json_schema_parsing_with_string(test_string, SampleModel.schema(), True)
+    _test_json_schema_parsing_with_string(test_string, SampleModel.model_json_schema(), True)
 
 
 def test_invalid_str_enum_value():
     test_string = '{"enum_dict":{"a":"Onee"},"num":1}'
-    _test_json_schema_parsing_with_string(test_string, SampleModel.schema(), False)
+    _test_json_schema_parsing_with_string(test_string, SampleModel.model_json_schema(), False)
 
 
 def test_whitespaces():
     test_string = '{ "message": "","num":1}'
-    _test_json_schema_parsing_with_string(test_string, SampleModel.schema(), True)
+    _test_json_schema_parsing_with_string(test_string, SampleModel.model_json_schema(), True)
 
 
 def test_whitespace_before_number():
     test_string = '{"num": 1, "dec": 1.1}'
-    _test_json_schema_parsing_with_string(test_string, SampleModel.schema(), True)
+    _test_json_schema_parsing_with_string(test_string, SampleModel.model_json_schema(), True)
 
 
 def test_whitespace_before_close():
     test_string = '{"num":1 }'
-    _test_json_schema_parsing_with_string(test_string, SampleModel.schema(), True)    
+    _test_json_schema_parsing_with_string(test_string, SampleModel.model_json_schema(), True)    
 
 
 def test_required_field():
     test_string = '{"dec": 1.1}'  # num is a required field, doesn't exist, should fail.
-    _test_json_schema_parsing_with_string(test_string, SampleModel.schema(), False)
+    _test_json_schema_parsing_with_string(test_string, SampleModel.model_json_schema(), False)
 
 
 def test_boolean_field():
-    _test_json_schema_parsing_with_string('{"num":1,"true_or_false":false}', SampleModel.schema(), True)
-    _test_json_schema_parsing_with_string('{"num":1,"true_or_false":true}', SampleModel.schema(), True)
-    _test_json_schema_parsing_with_string('{"num":1,"true_or_false": true}', SampleModel.schema(), True)
-    _test_json_schema_parsing_with_string('{"num":1,"true_or_false":falsy}', SampleModel.schema(), False)
+    _test_json_schema_parsing_with_string('{"num":1,"true_or_false":false}', SampleModel.model_json_schema(), True)
+    _test_json_schema_parsing_with_string('{"num":1,"true_or_false":true}', SampleModel.model_json_schema(), True)
+    _test_json_schema_parsing_with_string('{"num":1,"true_or_false": true}', SampleModel.model_json_schema(), True)
+    _test_json_schema_parsing_with_string('{"num":1,"true_or_false":falsy}', SampleModel.model_json_schema(), False)
 
 def test_unspecified_dict():
     class DictModel(BaseModel):
         num: int
         d: dict
 
-    _test_json_schema_parsing_with_string('{"num":1,"d":{"k":"v"}}', DictModel.schema(), True)
+    _test_json_schema_parsing_with_string('{"num":1,"d":{"k":"v"}}', DictModel.model_json_schema(), True)
 
 
 def test_unspecified_list():
@@ -147,63 +147,63 @@ def test_unspecified_list():
         num: int
         l: list
 
-    _test_json_schema_parsing_with_string('{"num":1,"l":[1,2,3,"b"]}', DictModel.schema(), True)
+    _test_json_schema_parsing_with_string('{"num":1,"l":[1,2,3,"b"]}', DictModel.model_json_schema(), True)
 
 
 def test_list_length_limitations():
     # list_of_strings is defined as having a min length of 2 and a max length of 3
     no_strings = '{"num":1,"list_of_strings":[]}'
-    _test_json_schema_parsing_with_string(no_strings, SampleModel.schema(), False)
+    _test_json_schema_parsing_with_string(no_strings, SampleModel.model_json_schema(), False)
     one_string = '{"num":1,"list_of_strings":["a"]}'
-    _test_json_schema_parsing_with_string(one_string, SampleModel.schema(), False)
+    _test_json_schema_parsing_with_string(one_string, SampleModel.model_json_schema(), False)
     two_strings = '{"num":1,"list_of_strings":["a", "b"]}'
-    _test_json_schema_parsing_with_string(two_strings, SampleModel.schema(), True)
+    _test_json_schema_parsing_with_string(two_strings, SampleModel.model_json_schema(), True)
     three_strings = '{"num":1,"list_of_strings":["a","b","c"]}'
-    _test_json_schema_parsing_with_string(three_strings, SampleModel.schema(), True)
+    _test_json_schema_parsing_with_string(three_strings, SampleModel.model_json_schema(), True)
     four_strings = '{"num":1,"list_of_strings":["a","b","c","d"]}'
-    _test_json_schema_parsing_with_string(four_strings, SampleModel.schema(), False)
+    _test_json_schema_parsing_with_string(four_strings, SampleModel.model_json_schema(), False)
 
     class EmptyListOKModel(BaseModel):
         num: int
         list_of_strings: Optional[List[str]] = Field(None, min_length=0, max_length=1)
-    _test_json_schema_parsing_with_string(no_strings, EmptyListOKModel.schema(), True)
-    _test_json_schema_parsing_with_string(one_string, EmptyListOKModel.schema(), True)
-    _test_json_schema_parsing_with_string(two_strings, EmptyListOKModel.schema(), False)
+    _test_json_schema_parsing_with_string(no_strings, EmptyListOKModel.model_json_schema(), True)
+    _test_json_schema_parsing_with_string(one_string, EmptyListOKModel.model_json_schema(), True)
+    _test_json_schema_parsing_with_string(two_strings, EmptyListOKModel.model_json_schema(), False)
 
     class ListOfExactlyOneModel(BaseModel):
         num: int
         list_of_strings: Optional[List[str]] = Field(None, min_length=1, max_length=1)
-    _test_json_schema_parsing_with_string(no_strings, ListOfExactlyOneModel.schema(), False)
-    _test_json_schema_parsing_with_string(one_string, ListOfExactlyOneModel.schema(), True)
-    _test_json_schema_parsing_with_string(two_strings, ListOfExactlyOneModel.schema(), False)
+    _test_json_schema_parsing_with_string(no_strings, ListOfExactlyOneModel.model_json_schema(), False)
+    _test_json_schema_parsing_with_string(one_string, ListOfExactlyOneModel.model_json_schema(), True)
+    _test_json_schema_parsing_with_string(two_strings, ListOfExactlyOneModel.model_json_schema(), False)
 
     class ListOfNoMinLengthModel(BaseModel):
         num: int
         list_of_strings: Optional[List[str]] = Field(None, max_length=1)
-    _test_json_schema_parsing_with_string(no_strings, ListOfNoMinLengthModel.schema(), True)
-    _test_json_schema_parsing_with_string(one_string, ListOfNoMinLengthModel.schema(), True)
-    _test_json_schema_parsing_with_string(two_strings, ListOfNoMinLengthModel.schema(), False)
+    _test_json_schema_parsing_with_string(no_strings, ListOfNoMinLengthModel.model_json_schema(), True)
+    _test_json_schema_parsing_with_string(one_string, ListOfNoMinLengthModel.model_json_schema(), True)
+    _test_json_schema_parsing_with_string(two_strings, ListOfNoMinLengthModel.model_json_schema(), False)
 
 
 def test_string_escaping():
     for escaping_character in BACKSLASH_ESCAPING_CHARACTERS:
         test_string = f'{{"num":1,"message":"hello {BACKSLASH}{escaping_character} world"}}'
-        _test_json_schema_parsing_with_string(test_string, SampleModel.schema(), True)
+        _test_json_schema_parsing_with_string(test_string, SampleModel.model_json_schema(), True)
     for non_escaping_character in 'a1?':
         test_string = f'{{"num":1,"message":"hello {BACKSLASH}{non_escaping_character} world"}}'
-        _test_json_schema_parsing_with_string(test_string, SampleModel.schema(), False)
+        _test_json_schema_parsing_with_string(test_string, SampleModel.model_json_schema(), False)
 
     # Unicode
     test_string = f'{{"num":1,"message":"hello {BACKSLASH}uf9f0 world"}}'
-    _test_json_schema_parsing_with_string(test_string, SampleModel.schema(), True)
+    _test_json_schema_parsing_with_string(test_string, SampleModel.model_json_schema(), True)
 
     # Not enough unicode digits
     test_string = f'{{"num":1,"message":"hello {BACKSLASH}uf9f world"}}'
-    _test_json_schema_parsing_with_string(test_string, SampleModel.schema(), False)
+    _test_json_schema_parsing_with_string(test_string, SampleModel.model_json_schema(), False)
 
     # Unicode digit outside of hex range
     test_string = f'{{"num":1,"message":"hello {BACKSLASH}uf9fP world"}}'
-    _test_json_schema_parsing_with_string(test_string, SampleModel.schema(), False)
+    _test_json_schema_parsing_with_string(test_string, SampleModel.model_json_schema(), False)
 
 
 def test_comma_after_all_object_keys_fails():
@@ -212,7 +212,7 @@ def test_comma_after_all_object_keys_fails():
 
     test_string = '{"key": "val",'
     with pytest.raises(CharacterNotAllowedException):
-        _test_json_schema_parsing_with_string(test_string, SomeSchema.schema(), True)
+        _test_json_schema_parsing_with_string(test_string, SomeSchema.model_json_schema(), True)
 
 
 def test_single_quote_must_not_be_escaped():
@@ -221,7 +221,7 @@ def test_single_quote_must_not_be_escaped():
 
     test_string = '{"key": "I\\\'m a string"}'
     with pytest.raises(CharacterNotAllowedException):
-        _test_json_schema_parsing_with_string(test_string, SomeSchema.schema(), True)
+        _test_json_schema_parsing_with_string(test_string, SomeSchema.model_json_schema(), True)
 
 
 def test_string_length_limitation():
@@ -233,7 +233,7 @@ def test_string_length_limitation():
     for str_length in range(10):
         test_string = f'{{"key": "{str_length * "a"}"}}'
         expect_sucess = 2 <= str_length <= 3
-        _test_json_schema_parsing_with_string(test_string, SomeSchema.schema(), expect_sucess)
+        _test_json_schema_parsing_with_string(test_string, SomeSchema.model_json_schema(), expect_sucess)
 
 
 def test_any_json_object():
@@ -263,7 +263,43 @@ def test_union():
     class SchemaWithUnion(BaseModel):
         key: Union[int, str]
 
-    _test_json_schema_parsing_with_string('{"key": 1}', SchemaWithUnion.schema(), True)
-    _test_json_schema_parsing_with_string('{"key": "a"}', SchemaWithUnion.schema(), True)
-    _test_json_schema_parsing_with_string('{"key": 1.2}', SchemaWithUnion.schema(), False)
-    _test_json_schema_parsing_with_string('{"key": false}', SchemaWithUnion.schema(), False)
+    _test_json_schema_parsing_with_string('{"key": 1}', SchemaWithUnion.model_json_schema(), True)
+    _test_json_schema_parsing_with_string('{"key": "a"}', SchemaWithUnion.model_json_schema(), True)
+    _test_json_schema_parsing_with_string('{"key": 1.2}', SchemaWithUnion.model_json_schema(), False)
+    _test_json_schema_parsing_with_string('{"key": false}', SchemaWithUnion.model_json_schema(), False)
+
+
+class StringConstraints(BaseModel):
+    min_5: Optional[str] = Field(None, min_length=5)
+    max_8: Optional[str] = Field(None, max_length=8)
+    max_16: Optional[str] = Field(None, max_length=16)
+    min_8_max_8: Optional[str] = Field(None, min_length=8, max_length=8)
+    min_4_max_6: Optional[str] = Field(None, min_length=4, max_length=6)
+
+
+def test_more_string_constraints():
+    for str_length in range(20):
+        test_string = f'{{"min_4_max_6": "{str_length * "#"}"}}'
+        expect_sucess = 4 <= str_length <= 6
+        print(test_string, expect_sucess)
+        _test_json_schema_parsing_with_string(test_string, StringConstraints.model_json_schema(), expect_sucess)
+
+    for k,v in {
+        'min_5': ['test5', 'test567'],
+        'max_8': ['test5678', 'test56'],
+        'max_16': ['123test??0123456', r'1\n\"'],
+        'min_8_max_8': ['12t, t78', r'##\\n####'],
+        'min_4_max_6': ['12_4', '12_4:5']
+    }.items():
+        for val in v:
+            print(val)
+            _test_json_schema_parsing_with_string(f'{{"{k}": "{val}"}}', StringConstraints.model_json_schema(), True)
+
+    for k,v in {
+        'min_5': 'test',
+        'max_8': 'te\nst',
+        'max_16': '123test89-1 34567',
+        'min_8_max_8': '12test7"',
+        'min_4_max_6': '12_'
+    }.items():
+        _test_json_schema_parsing_with_string(f'{{"{k}": "{v}"}}', StringConstraints.model_json_schema(), False)


### PR DESCRIPTION
This PR allows `json_freetext` optimization to be used with JSON schema strings that have a max length by making a separate cache for each possible token length encountered in the LLM tokenizer:
- In init, TokenizerPrefixTree builds a hash table of all possible allowed tokens per max token length. 
- At generation time, JsonSchemaParser then passes total characters left in current StringParsingState via shortcut_key as a tuple: `('json_freetext', chars_left)`
- Finally, `_collect_allowed_tokens()` looks up a list that contains tokens that are at most `chars_left` long.

Fixes #42