### PR TITLE
Fixed the issue of being unable to handle transformer added/expanded model tokens

### DIFF
--- a/lmformatenforcer/integrations/transformers.py
+++ b/lmformatenforcer/integrations/transformers.py
@@ -55,7 +55,7 @@ class LogitsSaverManager:
 def _build_regular_tokens_list(tokenizer: PreTrainedTokenizerBase) -> List[Tuple[int, str, bool]]:
     token_0 = tokenizer.encode("0")[-1]
     regular_tokens = []
-    for token_idx in range(tokenizer.vocab_size):
+    for token_idx in range(len(tokenizer)):
         if token_idx in tokenizer.all_special_ids:
             continue
         # We prepend token 0 and skip the first letter of the result to get a space if the token is a start word.


### PR DESCRIPTION
For transformers, tokenizer.vocab_size excludes all tokens added via token expansion. Correct usage here is len(tokenizer).

ref: https://stackoverflow.com/questions/67412925/what-is-the-difference-between-lentokenizer-and-tokenizer-vocab-size
ref: https://github.com/huggingface/tokenizers/issues/900#issuecomment-1028784677

Without this PR, any new custom tokens added to the transformer model and subsequently trained will be invisible to the lm-format-enforcer.