### PR TITLE
Allow regex to exit to forcestopparser when receiving a pad/eos token after having been in a final state.

### DIFF
--- a/lmformatenforcer/regexparser.py
+++ b/lmformatenforcer/regexparser.py
@@ -51,7 +51,7 @@ class RegexParser(CharacterLevelParser):
             return RegexParser(self.context, self.config, RegexParser.INVALID_STATE)
     
     def can_end(self) -> bool:
-        return self.current_state in self.context.pattern.finals
+        return self.current_state in self.context.pattern.finals or self.current_state == RegexParser.INVALID_STATE
     
     def get_allowed_characters(self) -> str:
         if self.current_state not in self.context.pattern.map:


### PR DESCRIPTION
See #86

Tests pass locally.
TBC why this didn't affect all models?