### PR TITLE
Fix slowdown after generating backslash escape sequences

### DIFF
--- a/lmformatenforcer/jsonschemaparser.py
+++ b/lmformatenforcer/jsonschemaparser.py
@@ -122,7 +122,7 @@ class JsonSchemaParser(CharacterLevelParser):
         current_parsers = []
         for parser in reversed(self.object_stack):
             current_parsers.append(parser)
-            if not parser.can_end():
+            if not parser.can_end() or len(parser.get_allowed_characters()) > 0:
                 break
         
         for current_parser in current_parsers:

--- a/lmformatenforcer/jsonschemaparser.py
+++ b/lmformatenforcer/jsonschemaparser.py
@@ -119,8 +119,13 @@ class JsonSchemaParser(CharacterLevelParser):
         return all(parser.can_end() for parser in self.object_stack)
 
     def shortcut_key(self) -> Optional[Hashable]:
-        if self.object_stack:
-            current_parser = self.object_stack[-1]
+        current_parsers = []
+        for parser in reversed(self.object_stack):
+            current_parsers.append(parser)
+            if not parser.can_end():
+                break
+        
+        for current_parser in current_parsers:
             if isinstance(current_parser, StringParsingState):
                 if not current_parser.allowed_strings and current_parser.seen_opening_quote and not current_parser.seen_closing_quote and not current_parser.regex_parser:
                     # Performance optimization: When we are parsing a string that is not from a list of allowed strings, most tokens


### PR DESCRIPTION
Addresses an issue I've seen which I believe is the same as what's reported in #90: an edge case where JSONSchemaParser's `shortcut_key` implementation did not consider the correct parser while finishing parsing an escape sequence. When the `UnionParser` that `StringParsingState` pops onto the stack after getting a `BACKSLASH` is finished but not yet removed from the stack, `shortcut_key` fails to return `json_freetext`.