### PR TITLE
Feature/escaping performance

### DIFF
--- a/lmformatenforcer/jsonschemaparser.py
+++ b/lmformatenforcer/jsonschemaparser.py
@@ -95,6 +95,9 @@ class JsonSchemaParser(CharacterLevelParser):
         # objects at the top of the stack, which we know will be passed over next timestep
         new_object_stack = updated_parser.object_stack
         while new_object_stack and new_object_stack[-1].can_end() and new_object_stack[-1].get_allowed_characters() == '':
+            finished_receiver = new_object_stack[-1]
+            if isinstance(finished_receiver, StringParsingState):
+                updated_parser.last_parsed_string = finished_receiver.parsed_string
             del new_object_stack[-1]
 
         return updated_parser

--- a/lmformatenforcer/jsonschemaparser.py
+++ b/lmformatenforcer/jsonschemaparser.py
@@ -91,6 +91,12 @@ class JsonSchemaParser(CharacterLevelParser):
                 option_json_schema_parsers.append(option_parser)
             return UnionParser(option_json_schema_parsers)
 
+        # For some performance optimizations to work, we want to make sure we don't leave irrelevant
+        # objects at the top of the stack, which we know will be passed over next timestep
+        new_object_stack = updated_parser.object_stack
+        while new_object_stack and new_object_stack[-1].can_end() and new_object_stack[-1].get_allowed_characters() == '':
+            del new_object_stack[-1]
+
         return updated_parser
 
     def get_allowed_characters(self) -> str:


### PR DESCRIPTION
A performance improvement that allows the shortcut/caching mechanisms to be active in more situations.
After the discussion in https://github.com/noamgat/lm-format-enforcer/pull/91 we found a more holistic way to solve this issue, and may positively affect other regions. Unit tests run faster.