### PR TITLE
fix: check that last_non_whitespace_character is not an empty string

### DIFF
--- a/lmformatenforcer/jsonschemaparser.py
+++ b/lmformatenforcer/jsonschemaparser.py
@@ -652,7 +652,7 @@ class ListParsingState(PrimitiveParsingState):
     def get_allowed_control_characters(self):
         num_items = self.num_items_seen
         is_on_top = self.root.context.active_parser.object_stack[-1] == self
-        if (not is_on_top) and self.root.context.active_parser.last_non_whitespace_character != "[":
+        if (not is_on_top) and self.root.context.active_parser.last_non_whitespace_character != "[" and self.root.context.active_parser.last_non_whitespace_character != "":
             # If there is an active parser above us, and the last character is not [, 
             # there is an active item parser on the stack that we did not count yet.
             num_items += 1

--- a/tests/test_jsonschemaparser.py
+++ b/tests/test_jsonschemaparser.py
@@ -243,6 +243,24 @@ def test_any_json_object():
     _test_json_schema_parsing_with_string('{"a": 1, "b": 2.2, "c": "c", "d": [1,2,3, null], "e": {"ee": 2}}', None, True)
     _test_json_schema_parsing_with_string("true", None, True)
     _test_json_schema_parsing_with_string('"str"', None, True)
+    
+    
+def test_leading_comma():
+    array_of_objects_schema = {
+        "type": "array",
+        "items": {
+            "type": "object",
+            "properties": {
+                "key": {
+                    "type": "string"
+                }
+            },
+            "required": ["key"]
+        }
+    }
+    
+    _test_json_schema_parsing_with_string('[{"key": "val"}, {"key": "val2"}]', array_of_objects_schema, True) 
+    _test_json_schema_parsing_with_string('[,{"key": "val"}]', array_of_objects_schema, False)
 
 
 def test_long_json_object():


### PR DESCRIPTION
Fixes the problem where JSON Schema could end up with leading commas.  The problem was that `last_non_whitespace_character` is set to an empty string if there has not been a non whitespace character, but the check that increments num_items didn't handle that case.

Dealign with the empty string is a bit unsatisfying, but I didn't feel comfortable with all of the implications of refactoring it other than to add the check.

Resolves #99