### PR TITLE
Support multiple EOS token ids + fix bugs in JsonSchemaParser

### DIFF
--- a/lmformatenforcer/integrations/trtllm.py
+++ b/lmformatenforcer/integrations/trtllm.py
@@ -15,7 +15,8 @@ class TRTLLMLogitsProcessor:
         self.eos_token_id = eos_token_id
 
     def _trim(self, input):
-        return [x for x in input.tolist() if x != self.eos_token_id]
+        return [x for x in input.tolist() if x not in \
+                (self.eos_token_id if isinstance(self.eos_token_id, list) else [self.eos_token_id])]
 
     def __call__(self, step: int, batch_input_ids: List[List[int]], logits: torch.Tensor) -> torch.Tensor:
         for idx in range(len(batch_input_ids)):

--- a/tests/common.py
+++ b/tests/common.py
@@ -55,8 +55,8 @@ def assert_parser_with_string_token_enforcer(string: str, parser: CharacterLevel
     # the parser the most.
     target_token_array = _tokenizer.encode(prompt + string)
     eos_token_id = _tokenizer.eos_token_id
-    if eos_token_id is None:
-        raise ValueError("Tokenizer does not have an EOS token")
+    if not eos_token_id:
+        raise ValueError(f"Tokenizer does not have {'an EOS token' if eos_token_id is None else 'EOS tokens'}")
     
     token_enforcer = TokenEnforcer(_tokenizer_data, parser)
     # The token enforcer is stateful - it keeps track of the parsing state as tokens arrive on a token by token basis.
@@ -82,7 +82,7 @@ def assert_parser_with_string_token_enforcer(string: str, parser: CharacterLevel
                     return  # Test success
         else:
             # Reached the end of the sequence, check that ending state matches expected ending state
-            can_end = eos_token_id in allowed_tokens
+            can_end = any(token in allowed_tokens for token in (eos_token_id if isinstance(eos_token_id, list) else [eos_token_id]))
             if can_end and not expect_success:
                 raise ValueError("Parser succeeded when it should have failed")
             if not can_end and expect_success:

--- a/tests/test_jsonschemaparser.py
+++ b/tests/test_jsonschemaparser.py
@@ -685,36 +685,93 @@ schema = NumberSchema.model_json_schema()
     '{"value": 1}',
     '{"value": 10}',
     '{"value": 0.1}',
-    '{"value": 1.01}',
+    '{"value": 1.01}', 
     '{"value": -1}',
     '{"value": -0.1}',
     '{"value": 1e5}',
-    '{"value": 1.5e-5}'
+    '{"value": 1.5e-5}',
+    '{"value": 1.5e5}',
+    '{"value": 1.5e+5}',
+    '{"value": -1.5e5}',
+    '{"value": -1.5e-5}',
+    '{"value": -1.5e+5}',
+    '{"value": 0.0}',
+    '{"value": -0.0}',
+    '{"value": 1.0}',
+    '{"value": -1.0}',
+    '{"value": 1.5e0}',
+    '{"value": -1.5e0}',
+    '{"value": 9007199254740991}',  
+    '{"value": -9007199254740991}',
+    '{"value": 1e-323}',
+    '{"value": 1.7976931348623157e+308}',
+    '{"value": 5e-324}',
+    '{"value": 2.2250738585072014e-308}',
 ])
 def test_valid_number_formats(test_input):
     _test_json_schema_parsing_with_string(test_input, schema, True)
 
 
 @pytest.mark.parametrize("test_input", [
-    '{"value": 01}',
+    '{"value": 01}',  
     '{"value": 00.1}',
     '{"value": 01.01}',
     '{"value": -01}',
     '{"value": -00.1}',
     '{"value": 01e5}',
-    '{"value": 00}'
+    '{"value": 00}',
+    '{"value": 00.0}',
+    '{"value": 00.0e5}',
+    '{"value": -00.0e5}',
+    '{"value": 0123}',
+    '{"value": -0123}',
+    '{"value": 01.23e45}',
 ])
 def test_invalid_number_formats_with_leading_zeros(test_input):
     _test_json_schema_parsing_with_string(test_input, schema, False)
 
 
 @pytest.mark.parametrize("test_input, expected_success", [
-    ('{"value": .1}', False),  # Missing leading zero
-    ('{"value": -.1}', False),  # Missing leading zero in negative number
-    ('{"value": 1.}', False),  # Trailing decimal point
-    ('{"value": +1}', False),  # Explicit positive sign
-    ('{"value": 1e}', False),  # Incomplete exponent
-    ('{"value": 1e+}', False),  # Incomplete exponent with sign
+    ('{"value": .1}', False),
+    ('{"value": -.1}', False),
+    ('{"value": 1.}', False),
+    ('{"value": +1}', False),
+    ('{"value": 1e}', False),
+    ('{"value": 1e+}', False),
+    ('{"value": .}', False),
+    ('{"value": -.}', False),
+    ('{"value": e5}', False),
+    ('{"value": .e5}', False),
+    ('{"value": -.e5}', False),
+    ('{"value": 1.5e}', False),
+    ('{"value": 1.5e+}', False),
+    ('{"value": -1.5e}', False),
+    ('{"value": -1.5e+}', False),
+    ('{"value": 1.5e-}', False),
+    ('{"value": -1.5e-}', False),
+    ('{"value": 1e-}', False),
+    ('{"value": -1e-}', False),
+    ('{"value": 1e+1e2}', False),
+    ('{"value": 1e1.5}', False),
+    ('{"value": 1e-1.5}', False),
+    ('{"value": 1e1a}', False),
+    ('{"value": 1e-1a}', False),
+    ('{"value": 0x123}', False),
+    ('{"value": 0b1010}', False),
+    ('{"value": 0o123}', False),
+    ('{"value": Infinity}', False),
+    ('{"value": -Infinity}', False),
+    ('{"value": NaN}', False),
+    ('{"value": 1,000}', False),
+    ('{"value": 1_000}', False),
+    ('{"value": 1.2.3}', False),
+    ('{"value": 1e2e3}', False),
+    ('{"value": 1e+2e-3}', False),
+    ('{"value": --1}', False),
+    ('{"value": ++1}', False),
+    ('{"value": +-1}', False),
+    ('{"value": 9007199254740992}', True),
+    ('{"value": -9007199254740992}', True),
 ])
 def test_number_edge_cases(test_input, expected_success):
     _test_json_schema_parsing_with_string(test_input, schema, expected_success)


### PR DESCRIPTION
Two contributions:
1. We modify the code so that it can support multiple EOS token ids, while also being backwards compatible. (This is necessary for some new models that have multiple stop tokens, otherwise the parser will not stop correctly.)
2. JsonSchemaParser was not handling `number` type correctly (leading zeros, decimal points, exponents like 1e5). I added a few dozen new test cases to cover this complex functionality and modified the `NumberParser` class. Coding style was a bit messy, completely open to any changes on that front. 