### PR TITLE
feat: add support for vLLM Mistral Tokenizer

### DIFF
--- a/lmformatenforcer/integrations/vllm.py
+++ b/lmformatenforcer/integrations/vllm.py
@@ -1,6 +1,7 @@
 try:
     import torch
     import vllm
+    from vllm.transformers_utils.tokenizer import MistralTokenizer
     from transformers import PreTrainedTokenizerBase
 except ImportError:
     raise ImportError('vllm is not installed. Please install it with "pip install vllm"')
@@ -35,6 +36,8 @@ def build_vllm_token_enforcer_tokenizer_data(tokenizer: Union[vllm.LLM, PreTrain
     # There are many classes that can be passed here, this logic should work on all of them.
     if hasattr(tokenizer, 'get_tokenizer'):
         tokenizer = tokenizer.get_tokenizer()
+    if isinstance(tokenizer, MistralTokenizer):
+        return build_token_enforcer_tokenizer_data(tokenizer)
     if hasattr(tokenizer, 'tokenizer'):
         tokenizer = tokenizer.tokenizer
     return build_token_enforcer_tokenizer_data(tokenizer)


### PR DESCRIPTION
fix https://github.com/noamgat/lm-format-enforcer/issues/141

The vllm [`MistralTokenizer`](https://github.com/vllm-project/vllm/blob/8fae5ed7f6bfd63b81310fcb24b310d9205c9687/vllm/transformers_utils/tokenizers/mistral.py#L43) class is a wrapper over the mistral tokenizers from [`mistral-common`](https://github.com/mistralai/mistral-common/tree/main/src/mistral_common/tokens/tokenizers).

When the `build_vllm_token_enforcer_tokenizer_data` function is called, the underlying `mistral-common` tokenizer is passed instead of the `MistralTokenizer`, which has the proper methods used by `lm-format-enforcer` to access the tokens and special tokens of the tokenizer.

This MR adds a check to directly pass the vllm `MistralTokenizer` tokenizer instead of the underlying `mistral-common` tokenizer when building the tokenizer data.