### PR TITLE
feat: add support for type "list of string"

### DIFF
--- a/lmformatenforcer/jsonschemaparser.py
+++ b/lmformatenforcer/jsonschemaparser.py
@@ -262,6 +262,9 @@ def get_parser(
     elif value_schema.type == "array":
         item_schema = value_schema.items or JsonSchemaParser.ANY_JSON_OBJECT_SCHEMA
         return ListParsingState(parsing_state, item_schema, value_schema.minItems, value_schema.maxItems)
+    elif isinstance(value_schema.type, list):
+        parsers = [get_parser(parsing_state, JsonSchemaObject(type=schema)) for schema in value_schema.type]
+        return UnionParser(parsers)
     else:
         raise Exception("Unsupported type " + str(value_schema.type))
 

--- a/tests/test_jsonschemaparser.py
+++ b/tests/test_jsonschemaparser.py
@@ -310,6 +310,34 @@ def test_allof():
         _test_json_schema_parsing_with_string(test_string, allof_schema, False)
 
 
+def test_type_string_list():
+    # A list of string can be used to describe multiple types
+    # https://json-schema.org/understanding-json-schema/reference/type
+    type_string_list_schema = {
+        "type": ["number", "string"]
+    }
+
+    # Valid cases
+    valid_test_strings = [
+        '42',
+        '42.0',
+        '"42.0"',
+        '"life is good"',
+    ]
+
+    # Invalid cases
+    invalid_test_strings = [
+        '{"num": 123}',  # object
+        '["not", "good"]',  # list of string
+        '["42", 43]',  # list of mix types
+    ]
+
+    for test_string in valid_test_strings:
+        _test_json_schema_parsing_with_string(test_string, type_string_list_schema, True)
+
+    for test_string in invalid_test_strings:
+        _test_json_schema_parsing_with_string(test_string, type_string_list_schema, False)
+
 def test_leading_comma():
     array_of_objects_schema = {
         "type": "array",


### PR DESCRIPTION
According to the [json-schema reference](https://json-schema.org/understanding-json-schema/reference/type), the `type` value can not only be a `string` describing the data type for the schema but also a list of string if the data type can take several of the types.

This PR add support for the list of strings type.

(we discovered the issue when using lm-format-enforcer on vLLM using the following schema:

```
        {
            "name": "VoiceNote",
            "schema": {
                "type": "object",
                "properties": {
                    "title": {
                        "type": ["string", "null"]
                    },
                    "summary": {
                        "type": "string"
                    },
                    "actionItems": {
                        "type": "array",
                        "items": {
                            "type": "string"
                        }
                    }
                },
                "additionalProperties": False,
                "required": [
                    "title", "summary", "actionItems"
                ]
            }
        }

```
