### PR TITLE
fix: handle boolean additionalProperties in JSON schema parsing

### DIFF
--- a/lmformatenforcer/jsonschemaparser.py
+++ b/lmformatenforcer/jsonschemaparser.py
@@ -342,7 +342,7 @@ class ObjectParsingState(BaseParsingState):
                 self.current_key = self.root.context.active_parser.last_parsed_string
                 self.existing_keys.append(self.current_key)
                 if self.is_dictionary:
-                    if self.schema_object.additionalProperties:
+                    if isinstance(self.schema_object.additionalProperties, JsonSchemaObject):
                         value_schema = self.schema_object.additionalProperties
                     else:
                         value_schema = JsonSchemaParser.ANY_JSON_OBJECT_SCHEMA

--- a/tests/test_jsonschemaparser.py
+++ b/tests/test_jsonschemaparser.py
@@ -831,3 +831,37 @@ def test_additional_properties():
     schema = {'type': 'object', 'properties': {'snippets': {'title': 'snippets', 'type': 'string'}, 'overall_sentiment': {'title': 'overall_sentiment', 'type': 'string'}}, 'required': ['snippets', 'overall_sentiment'], 'additionalProperties': False, 'definitions': {}} 
     completion = """{"snippets": "What a beautiful day", "overall_sentiment": "Positive"}"""
     _test_json_schema_parsing_with_string(completion, schema, True)
+
+
+def test_additional_properties_boolean_true():
+    """Issue #69: additionalProperties=True on a dictionary-style object should not crash."""
+    schema = {
+        "type": "object",
+        "additionalProperties": True
+    }
+    # Should accept any key/value pairs
+    _test_json_schema_parsing_with_string('{"key": "value"}', schema, True)
+    _test_json_schema_parsing_with_string('{"a": 1, "b": "hello"}', schema, True)
+    _test_json_schema_parsing_with_string('{}', schema, True)
+
+
+def test_additional_properties_boolean_false_dict():
+    """Issue #69: additionalProperties=False on a dictionary-style object should not crash."""
+    schema = {
+        "type": "object",
+        "additionalProperties": False
+    }
+    # Should still allow parsing (False is treated as any-type fallback since there are no properties defined)
+    _test_json_schema_parsing_with_string('{"key": "value"}', schema, True)
+    _test_json_schema_parsing_with_string('{}', schema, True)
+
+
+def test_additional_properties_schema_object():
+    """additionalProperties as a schema object should constrain value types."""
+    schema = {
+        "type": "object",
+        "additionalProperties": {"type": "integer"}
+    }
+    _test_json_schema_parsing_with_string('{"a": 1, "b": 2}', schema, True)
+    _test_json_schema_parsing_with_string('{"a": "string_value"}', schema, False)
+


### PR DESCRIPTION
## Summary

Fixes #69.

When `additionalProperties` is set to a boolean value (`true` or `false`) in a JSON schema for a dictionary-style object (no `properties` key), the parser crashes with:

```
AttributeError: 'bool' object has no attribute 'anyOf'
```

This happens because the truthy check `if self.schema_object.additionalProperties:` passes when the value is `True`, and the boolean is then passed directly to `get_parser()`, which expects a `JsonSchemaObject`.

## Changes

- Changed the check in `ObjectParsingState.add_character()` from a truthy check to an `isinstance(self.schema_object.additionalProperties, JsonSchemaObject)` check, so that boolean values correctly fall through to the `ANY_JSON_OBJECT_SCHEMA` default.
- Added three new test cases covering:
  - `additionalProperties: true` on dictionary-style objects
  - `additionalProperties: false` on dictionary-style objects
  - `additionalProperties` as a schema object (regression test)

## Testing

- All new tests pass
- Reproduction script from the issue no longer raises an exception
- Existing test for `additionalProperties: false` with `properties` still passes