### PR TITLE
fix: disable clean_up_tokenization_spaces in _decode_function to prevent JSON truncation (#166)

### DIFF
--- a/lmformatenforcer/integrations/transformers.py
+++ b/lmformatenforcer/integrations/transformers.py
@@ -68,9 +68,14 @@ def _build_regular_tokens_list(tokenizer: PreTrainedTokenizerBase, vocab_size: i
 
 
 def _decode_function(tokenizer: PreTrainedTokenizerBase, tokens: List[int]) -> str:
-    decoded = tokenizer.decode(tokens)
-    cleaned = decoded.rstrip('�')
-    return cleaned
+    # Disable clean_up_tokenization_spaces to prevent whitespace collapsing and
+    # punctuation normalization. Without this, tokenizer.decode() can silently drop
+    # characters (e.g. commas, spaces) when computing incremental new_characters in
+    # _apply_new_characters, causing the JSON parser state to desync and allowing
+    # premature EOS generation with incomplete/truncated JSON output.
+    # See: https://github.com/noamgat/lm-format-enforcer/issues/166
+    decoded = tokenizer.decode(tokens, clean_up_tokenization_spaces=False)
+    return decoded
 
 
 def build_token_enforcer_tokenizer_data(tokenizer: PreTrainedTokenizerBase, 


### PR DESCRIPTION
## Problem

Fixes #166

`_decode_function` in `transformers.py` was calling `tokenizer.decode()` with the default `clean_up_tokenization_spaces=True`. This causes the tokenizer to collapse whitespace runs and normalize punctuation, which breaks the incremental character diffing in `_apply_new_characters` inside `tokenenforcer.py`.

### Root cause

When computing new characters added by a new token:
```python
prev_decoded = self.decoder(state.current_word_tokens)
new_decoded  = self.decoder(new_state.current_word_tokens)
new_characters = new_decoded[len(prev_decoded):]
```

The cleanup step can produce different lengths for sequences that differ only in trailing tokens. For example with Llama-3 tokenizer:
```python
self.decoder([...tokens])        # => ' avoid a"\n  '   (2 spaces)
self.decoder([...tokens, 1359])  # => ' avoid a"\n ,"'  (space collapsed + comma added)

# Result:
new_characters = '"'   # comma was silently dropped!
```

Because the `,` never reaches the JSON parser state, the parser may allow EOS to be generated, producing incomplete/truncated JSON.

Additionally, `.rstrip('\ufffd')` caused the same class of bug when a model generated a replacement-character token — stripping it prevented it from being tracked by the parser, again allowing premature EOS.

## Fix

Pass `clean_up_tokenization_spaces=False` to `tokenizer.decode()` and remove `.rstrip('\ufffd')`, ensuring every character (spaces, commas, quotes, newlines) is faithfully counted when diffing token sequences.

```python
# Before
def _decode_function(tokenizer, tokens):
    decoded = tokenizer.decode(tokens)
    cleaned = decoded.rstrip('\ufffd')
    return cleaned

# After
def _decode_function(tokenizer, tokens):
    decoded = tokenizer.decode(tokens, clean_up_tokenization_spaces=False)
    return decoded
```

## Testing

This can be reproduced by running a Llama-3 model with a JSON schema that includes string fields followed by other fields — with the old code the output is silently truncated; with this fix the full valid JSON is produced.
